### PR TITLE
Updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,13 @@
 Package: pysparklyr
-Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9001
-Authors@R: 
-    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
-           comment = c(ORCID = "YOUR-ORCID-ID"))
-Description: What the package does (one paragraph).
+Title: Provides a 'PySpark' back-end for the 'sparklyr' package
+Version: 0.0.0.9002
+Authors@R: c(
+    person("Edgar", "Ruiz", , "edgar@posit.co", role = c("aut", "cre")),
+    person(given = "Posit Software, PBC", role = c("cph", "fnd"))
+    )
+Description: It enables 'sparklyr' to integrate with 'Spark Connect', and
+    'Databricks Connect' by providing a wrapper over the 'PySpark' 'python'
+    library.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -24,7 +27,7 @@ Imports:
     fs,
     magrittr,
     tidyr
-URL: https://github.com/edgararuiz/pysparklyr
-BugReports: https://github.com/edgararuiz/pysparklyr/issues
+URL: https://github.com/mlverse/pysparklyr
+BugReports: https://github.com/mlverse/pysparklyr/issues
 Remotes:  
     sparklyr/sparklyr

--- a/R/data-read.R
+++ b/R/data-read.R
@@ -160,7 +160,7 @@ pyspark_read_generic <- function(sc, path, name, format, memory, repartition,
                                  overwrite, args, options = list()) {
   opts <- c(args, options)
 
-  if(inherits(sc, "pyspark_connection")) {
+  if (inherits(sc, "pyspark_connection")) {
     x <- python_conn(sc)$read %>%
       py_invoke_options(options = opts) %>%
       py_invoke(format, path_expand(path))

--- a/R/data-read.R
+++ b/R/data-read.R
@@ -142,36 +142,17 @@ spark_read_parquet.pyspark_connection <- function(
     read <- con$read$parquet(path)
   }
 
-  finalize_read(read, sc, name, memory, repartition, overwrite)
-}
-
-finalize_read <- function(x, sc, name, memory, repartition, overwrite) {
-  repartition <- as.integer(repartition)
-  if (repartition > 0) {
-    x$repartition(repartition)
-  }
-
-  if (overwrite && name %in% dbListTables(sc)) {
-    dbRemoveTable(sc, name)
-  }
-
-  if (is.null(name)) {
-    name <- random_string()
-  }
-
-  x$createTempView(name)
-
-  if (memory) {
-    # temp_name <- glue("sparklyr_tmp_{random_string()}")
-    # x$createTempView(temp_name)
-    # temp_table <- tbl(sc, temp_name)
-    # cache_query(table = temp_table, name = name)
-    storage_level <- import("pyspark.storagelevel")
-    x$persist(storage_level$StorageLevel$MEMORY_AND_DISK)
-  }
-
-  spark_ide_connection_updated(sc, name)
-  tbl(sc, name)
+  pyspark_read_generic(
+    sc = read,
+    path = NULL,
+    name = name,
+    format = NULL,
+    memory = memory,
+    repartition = repartition,
+    overwrite = overwrite,
+    options = NULL,
+    args = NULL
+  )
 }
 
 
@@ -179,9 +160,13 @@ pyspark_read_generic <- function(sc, path, name, format, memory, repartition,
                                  overwrite, args, options = list()) {
   opts <- c(args, options)
 
-  x <- python_conn(sc)$read %>%
-    py_invoke_options(options = opts) %>%
-    py_invoke(format, path_expand(path))
+  if(inherits(sc, "pyspark_connection")) {
+    x <- python_conn(sc)$read %>%
+      py_invoke_options(options = opts) %>%
+      py_invoke(format, path_expand(path))
+  } else {
+    x <- sc
+  }
 
   repartition <- as.integer(repartition)
   if (repartition > 0) {
@@ -199,10 +184,6 @@ pyspark_read_generic <- function(sc, path, name, format, memory, repartition,
   x$createTempView(name)
 
   if (memory) {
-    # temp_name <- glue("sparklyr_tmp_{random_string()}")
-    # x$createTempView(temp_name)
-    # temp_table <- tbl(sc, temp_name)
-    # cache_query(table = temp_table, name = name)
     storage_level <- import("pyspark.storagelevel")
     x$persist(storage_level$StorageLevel$MEMORY_AND_DISK)
   }

--- a/R/data-write.R
+++ b/R/data-write.R
@@ -105,10 +105,7 @@ spark_write_json.tbl_pyspark <- function(
 }
 
 pyspark_write_generic <- function(x, path, format, mode, partition_by, options, args) {
-  sc <- spark_connection(x)
-  con <- python_conn(sc)
-
-  query <- con$sql(remote_query(x))
+  query <- tbl_pyspark_sdf(x)
 
   if (is.null(partition_by)) {
     query_prep <- query$repartition(1L)$write

--- a/R/integ-test.R
+++ b/R/integ-test.R
@@ -1,0 +1,25 @@
+#' @export
+spark_integ_test_skip.pyspark_connection <- function(sc, test_name) {
+  out <- TRUE
+  if(grepl("dplyr", test_name)) out <- FALSE
+  if(grepl("dplyr-do", test_name)) out <- TRUE
+  if(grepl("dplyr-hof", test_name)) out <- TRUE
+  if(grepl("dplyr-cumprod", test_name)) out <- TRUE
+
+  if(grepl("sample-n-weights", test_name)) out <- TRUE
+  if(grepl("sample-n-replace", test_name)) out <- TRUE
+
+  if(grepl("sample-with-seed", test_name)) out <- TRUE
+
+  if(grepl("sample-frac-weights", test_name)) out <- TRUE
+  if(grepl("sample-frac-replace", test_name)) out <- TRUE
+  if(grepl("sample-frac-exact", test_name)) out <- TRUE
+
+  if(grepl("dbi", test_name)) out <- FALSE
+  if(grepl("sdf-broadcast", test_name)) out <- TRUE
+  if(grepl("ml-", test_name)) out <- TRUE
+
+  if(grepl("supports-nas", test_name)) out <- TRUE
+
+  out
+}

--- a/R/integ-test.R
+++ b/R/integ-test.R
@@ -1,25 +1,25 @@
 #' @export
 spark_integ_test_skip.pyspark_connection <- function(sc, test_name) {
   out <- TRUE
-  if(grepl("dplyr", test_name)) out <- FALSE
-  if(grepl("dplyr-do", test_name)) out <- TRUE
-  if(grepl("dplyr-hof", test_name)) out <- TRUE
-  if(grepl("dplyr-cumprod", test_name)) out <- TRUE
+  if (grepl("dplyr", test_name)) out <- FALSE
+  if (grepl("dplyr-do", test_name)) out <- TRUE
+  if (grepl("dplyr-hof", test_name)) out <- TRUE
+  if (grepl("dplyr-cumprod", test_name)) out <- TRUE
 
-  if(grepl("sample-n-weights", test_name)) out <- TRUE
-  if(grepl("sample-n-replace", test_name)) out <- TRUE
+  if (grepl("sample-n-weights", test_name)) out <- TRUE
+  if (grepl("sample-n-replace", test_name)) out <- TRUE
 
-  if(grepl("sample-with-seed", test_name)) out <- TRUE
+  if (grepl("sample-with-seed", test_name)) out <- TRUE
 
-  if(grepl("sample-frac-weights", test_name)) out <- TRUE
-  if(grepl("sample-frac-replace", test_name)) out <- TRUE
-  if(grepl("sample-frac-exact", test_name)) out <- TRUE
+  if (grepl("sample-frac-weights", test_name)) out <- TRUE
+  if (grepl("sample-frac-replace", test_name)) out <- TRUE
+  if (grepl("sample-frac-exact", test_name)) out <- TRUE
 
-  if(grepl("dbi", test_name)) out <- FALSE
-  if(grepl("sdf-broadcast", test_name)) out <- TRUE
-  if(grepl("ml-", test_name)) out <- TRUE
+  if (grepl("dbi", test_name)) out <- FALSE
+  if (grepl("sdf-broadcast", test_name)) out <- TRUE
+  if (grepl("ml-", test_name)) out <- TRUE
 
-  if(grepl("supports-nas", test_name)) out <- TRUE
+  if (grepl("supports-nas", test_name)) out <- TRUE
 
   out
 }

--- a/R/integ-test.R
+++ b/R/integ-test.R
@@ -1,25 +1,24 @@
 #' @export
 spark_integ_test_skip.pyspark_connection <- function(sc, test_name) {
+
+  supports <- function(x, test, default_out = FALSE) {
+    if (grepl(test, test_name)) {
+      x <- default_out
+    }
+    x
+  }
+
   out <- TRUE
-  if (grepl("dplyr", test_name)) out <- FALSE
-  if (grepl("dplyr-do", test_name)) out <- TRUE
-  if (grepl("dplyr-hof", test_name)) out <- TRUE
-  if (grepl("dplyr-cumprod", test_name)) out <- TRUE
 
-  if (grepl("sample-n-weights", test_name)) out <- TRUE
-  if (grepl("sample-n-replace", test_name)) out <- TRUE
-
-  if (grepl("sample-with-seed", test_name)) out <- TRUE
-
-  if (grepl("sample-frac-weights", test_name)) out <- TRUE
-  if (grepl("sample-frac-replace", test_name)) out <- TRUE
-  if (grepl("sample-frac-exact", test_name)) out <- TRUE
-
-  if (grepl("dbi", test_name)) out <- FALSE
-  if (grepl("sdf-broadcast", test_name)) out <- TRUE
-  if (grepl("ml-", test_name)) out <- TRUE
-
-  if (grepl("supports-nas", test_name)) out <- TRUE
-
-  out
+  out %>%
+    supports("dplyr") %>%
+    supports("dplyr-do", TRUE) %>%
+    supports("dplyr_hof", TRUE) %>%
+    supports("dplyr-cumprod", TRUE) %>%
+    supports("DBI") %>%
+    supports("format-csv") %>%
+    supports("format-parquet") %>%
+    supports("format-orc") %>%
+    supports("format-json") %>%
+    supports("format-text")
 }

--- a/R/methods-dplyr.R
+++ b/R/methods-dplyr.R
@@ -1,21 +1,19 @@
 #' @export
 sample_n.tbl_pyspark <- function(tbl, size, replace = FALSE,
-                                    weight = NULL, .env = NULL, ...
-                                    ) {
+                                 weight = NULL, .env = NULL, ...) {
   slice_sample(
     .data = tbl,
     n = size,
     replace = replace,
-    weight_by = !! enquo(weight)
-    )
+    weight_by = !!enquo(weight)
+  )
 }
 
 #' @export
 sample_frac.tbl_pyspark <- function(tbl, size = 1, replace = FALSE,
-                                       weight = NULL, .env = NULL, ...
-                                       ){
+                                    weight = NULL, .env = NULL, ...) {
   weight <- enquo(weight)
-  if(!quo_is_null(weight)) {
+  if (!quo_is_null(weight)) {
     abort("`weight` is not supported in this Spark connection")
   }
   df <- tbl_pyspark_sdf(tbl)
@@ -31,10 +29,9 @@ compute.tbl_pyspark <- function(x, name = NULL, ...) {
 
 cache_query <- function(table,
                         name = NULL,
-                        storage_level = "MEMORY_AND_DISK"
-                        ) {
+                        storage_level = "MEMORY_AND_DISK") {
   # https://spark.apache.org/docs/latest/sql-ref-syntax-aux-cache-cache-table.html
-  if(is.null(name)) {
+  if (is.null(name)) {
     name <- random_string()
   }
   x <- remote_query(table)
@@ -87,10 +84,10 @@ sdf_copy_to.pyspark_connection <- function(sc,
 
 
   repartition <- as.integer(repartition)
-  if(repartition > 0) {
+  if (repartition > 0) {
     df_copy$createTempView(name)
     df_copy$repartition(repartition)
-    if(memory) {
+    if (memory) {
       storage_level <- import("pyspark.storagelevel")
       df_copy$persist(storage_level$StorageLevel$MEMORY_AND_DISK)
     }
@@ -137,8 +134,8 @@ tidyselect_data_has_predicates.tbl_pyspark <- function(x) {
 #' @export
 same_src.pyspark_connection <- function(x, y) {
   identical(x$master, y$master) &&
-  identical(x$method, y$method) &&
-  identical(x$state, y$state)
+    identical(x$method, y$method) &&
+    identical(x$state, y$state)
 }
 
 tbl_pyspark_sdf <- function(x) {
@@ -151,7 +148,7 @@ tbl_temp_name <- function() glue("{temp_prefix()}{random_string()}")
 
 tbl_pyspark_temp <- function(x, conn, tmp_name = NULL) {
   sc <- spark_connection(conn)
-  if(is.null(tmp_name)) {
+  if (is.null(tmp_name)) {
     tmp_name <- tbl_temp_name()
   }
   x$createOrReplaceTempView(tmp_name)

--- a/R/methods-tidyr.R
+++ b/R/methods-tidyr.R
@@ -1,22 +1,20 @@
 #' @export
 pivot_longer.tbl_pyspark <- function(
-  data,
-  cols,
-  ...,
-  cols_vary = "fastest",
-  names_to = "name",
-  names_prefix = NULL,
-  names_sep = NULL,
-  names_pattern = NULL,
-  names_ptypes = NULL,
-  names_transform = NULL,
-  names_repair = "check_unique",
-  values_to = "value",
-  values_drop_na = FALSE,
-  values_ptypes = NULL,
-  values_transform = NULL
-  ){
-
+    data,
+    cols,
+    ...,
+    cols_vary = "fastest",
+    names_to = "name",
+    names_prefix = NULL,
+    names_sep = NULL,
+    names_pattern = NULL,
+    names_ptypes = NULL,
+    names_transform = NULL,
+    names_repair = "check_unique",
+    values_to = "value",
+    values_drop_na = FALSE,
+    values_ptypes = NULL,
+    values_transform = NULL) {
   sc <- spark_connection(data)
 
   spark_df <- tbl_pyspark_sdf(data)
@@ -31,17 +29,17 @@ pivot_longer.tbl_pyspark <- function(
   temp_name <- tbl_temp_name()
   te_df <- tbl_pyspark_temp(spark_df, data, temp_name)
   col_names <- te_df %>%
-    select(!! enquo(cols)) %>%
+    select(!!enquo(cols)) %>%
     colnames()
 
-  if(length(col_names) == 0) {
+  if (length(col_names) == 0) {
     abort("`cols` must select at least one column.")
   }
 
   # Determining what columns are NOT selected
   col_all <- spark_df$columns
   col_dif <- col_all
-  for(col in col_names) {
+  for (col in col_names) {
     col_dif <- col_dif[col_dif != col]
   }
 
@@ -49,26 +47,25 @@ pivot_longer.tbl_pyspark <- function(
   # I chose to pass the first one, and then remove it after performing the
   # un-pivot operation. Not ideal, but it works
   remove_first <- FALSE
-  if(length(col_dif) == 0) {
+  if (length(col_dif) == 0) {
     col_dif <- col_all[1]
     remove_first <- TRUE
   }
 
   # If there is a name separator, this loop will process to
   # PySpark unpivot ops
-  if(length(names_to) > 1) {
-
+  if (length(names_to) > 1) {
     if (!is.null(names_sep)) {
       output_names <- .str_separate(col_names, names_to, sep = names_sep)
     } else {
       output_names <- .str_extract(col_names, names_to, regex = names_pattern)
     }
 
-    if(length(names_to) > 2) {
+    if (length(names_to) > 2) {
       abort("Only two level is supported")
     }
 
-    if(names_to[[1]] == ".value") {
+    if (names_to[[1]] == ".value") {
       val_no <- 1
       nm_no <- 2
     } else {
@@ -81,7 +78,7 @@ pivot_longer.tbl_pyspark <- function(
     u_val <- unique(val_vals)
 
     all_pv <- NULL
-    for(i in seq_along(u_val)) {
+    for (i in seq_along(u_val)) {
       nm_rm <- list()
       c_val <- u_val[[i]]
       nm_rm[[val_no]] <- c_val
@@ -89,12 +86,12 @@ pivot_longer.tbl_pyspark <- function(
       nm_rm <- paste0(nm_rm, collapse = "")
       cur_cols <- col_names[which(val_vals == c_val)]
       sel_df <- spark_df$select(c(col_dif, cur_cols))
-      for(j in seq_along(cur_cols)) {
-        ren_cols <-  sub(nm_rm, "", cur_cols)
+      for (j in seq_along(cur_cols)) {
+        ren_cols <- sub(nm_rm, "", cur_cols)
         sel_df <- sel_df$withColumnRenamed(
           existing = cur_cols[[j]],
           new = sub(nm_rm, "", ren_cols[[j]])
-          )
+        )
       }
 
       check_same_types(x = sel_df, col_names = ren_cols)
@@ -111,10 +108,10 @@ pivot_longer.tbl_pyspark <- function(
     }
 
     out <- NULL
-    for(i in seq_along(all_pv)) {
+    for (i in seq_along(all_pv)) {
       no_i <- length(all_pv) - i + 1
-      if(no_i > 1) {
-        if(is.null(out)) out <- all_pv[[no_i]]
+      if (no_i > 1) {
+        if (is.null(out)) out <- all_pv[[no_i]]
         next_df <- all_pv[[(no_i - 1)]]
         out <- out$join(
           other = next_df,
@@ -128,9 +125,7 @@ pivot_longer.tbl_pyspark <- function(
     output_cols <- output_cols[output_cols != ".value"]
 
     out <- out$select(as.list(c(col_dif, output_cols, u_val)))
-
   } else {
-
     check_same_types(x = spark_df, col_names = col_names)
 
     out <- un_pivot(
@@ -141,7 +136,7 @@ pivot_longer.tbl_pyspark <- function(
       values_to = values_to,
       remove_first = remove_first,
       values_drop_na = values_drop_na
-      )
+    )
   }
 
   # Cleaning up by removing the temp view with the operations
@@ -153,9 +148,7 @@ pivot_longer.tbl_pyspark <- function(
 }
 
 un_pivot <- function(x, ids, values, names_to,
-                     values_to, remove_first, values_drop_na
-                     ) {
-
+                     values_to, remove_first, values_drop_na) {
   out <- x$unpivot(
     ids = as.list(ids),
     values = as.list(values),
@@ -163,11 +156,11 @@ un_pivot <- function(x, ids, values, names_to,
     valueColumnName = values_to
   )
 
-  if(remove_first) {
+  if (remove_first) {
     out <- out$select(list(names_to, values_to))
   }
 
-  if(values_drop_na) {
+  if (values_drop_na) {
     out <- out$dropna(subset = values_to)
   }
   out
@@ -178,11 +171,10 @@ check_same_types <- function(x, col_names) {
   char_types <- map_chr(dtypes, ~ .x[[2]])
   char_match <- length(unique(char_types)) == 1
 
-  if(!char_match) {
+  if (!char_match) {
     type_names <- map_chr(dtypes, ~ paste0(.x[[1]], " <", .x[[2]], ">"))
     abort(glue(
       "There is a data type mismatch: {paste0(type_names, collapse = ' ')}"
     ))
   }
-
 }

--- a/R/package.R
+++ b/R/package.R
@@ -27,3 +27,6 @@
 NULL
 
 pysparklyr_env <- new.env()
+pysparklyr_env$temp_prefix <- "sparklyr_tmp_"
+temp_prefix <- function() pysparklyr_env$temp_prefix
+

--- a/R/package.R
+++ b/R/package.R
@@ -29,4 +29,3 @@ NULL
 pysparklyr_env <- new.env()
 pysparklyr_env$temp_prefix <- "sparklyr_tmp_"
 temp_prefix <- function() pysparklyr_env$temp_prefix
-

--- a/R/pyspark-connection.R
+++ b/R/pyspark-connection.R
@@ -19,6 +19,8 @@ spark_integ_test_skip.pyspark_connection <- function(sc, test_name) {
   if(grepl("sdf-broadcast", test_name)) out <- TRUE
   if(grepl("ml-", test_name)) out <- TRUE
 
+  if(grepl("supports-nas", test_name)) out <- TRUE
+
   out
 }
 

--- a/R/pyspark-connection.R
+++ b/R/pyspark-connection.R
@@ -1,32 +1,6 @@
 #' @export
-spark_integ_test_skip.pyspark_connection <- function(sc, test_name) {
-  out <- TRUE
-  if(grepl("dplyr", test_name)) out <- FALSE
-  if(grepl("dplyr-do", test_name)) out <- TRUE
-  if(grepl("dplyr-hof", test_name)) out <- TRUE
-  if(grepl("dplyr-cumprod", test_name)) out <- TRUE
-
-  if(grepl("sample-n-weights", test_name)) out <- TRUE
-  if(grepl("sample-n-replace", test_name)) out <- TRUE
-
-  if(grepl("sample-with-seed", test_name)) out <- TRUE
-
-  if(grepl("sample-frac-weights", test_name)) out <- TRUE
-  if(grepl("sample-frac-replace", test_name)) out <- TRUE
-  if(grepl("sample-frac-exact", test_name)) out <- TRUE
-
-  if(grepl("dbi", test_name)) out <- FALSE
-  if(grepl("sdf-broadcast", test_name)) out <- TRUE
-  if(grepl("ml-", test_name)) out <- TRUE
-
-  if(grepl("supports-nas", test_name)) out <- TRUE
-
-  out
-}
-
-#' @export
 spark_version.pyspark_connection <- function(sc) {
-  sc$state$spark_context$version
+  python_conn(sc)$version
 }
 
 #' @export
@@ -54,7 +28,7 @@ spark_session.pyspark_connection <- function(sc) {
 invoke.pyspark_connection <- function(jobj, method, ...) {
   invoke_conn(
     jobj = jobj,
-    context = jobj$state$spark_context,
+    context = python_conn(jobj),
     method = method,
     ... = ...
   )

--- a/R/spark-connect.R
+++ b/R/spark-connect.R
@@ -11,13 +11,12 @@ spark_connect_method.spark_method_spark_connect <- function(
     extensions,
     scala_version,
     ...) {
-
   py_spark_connect(
     master = master,
     method = method,
     config = config,
     ... = ...
-    )
+  )
 }
 
 #' @export
@@ -33,7 +32,6 @@ spark_connect_method.spark_method_databricks_connect <- function(
     extensions,
     scala_version,
     ...) {
-
   py_spark_connect(
     master = master,
     method = method,
@@ -51,7 +49,6 @@ py_spark_connect <- function(master,
                              spark_version = NULL,
                              databricks_connect_version = NULL,
                              config = list()) {
-
   method <- method[[1]]
 
   virtualenv_name <- env_version(
@@ -72,11 +69,11 @@ py_spark_connect <- function(master,
   }
 
   if (method == "databricks_connect") {
-    if(is.null(master)) {
-      master <-  Sys.getenv("DATABRICKS_HOST")
+    if (is.null(master)) {
+      master <- Sys.getenv("DATABRICKS_HOST")
     }
-    if(is.null(cluster_id)) {
-      cluster_id <-  Sys.getenv("DATABRICKS_CLUSTER_ID")
+    if (is.null(cluster_id)) {
+      cluster_id <- Sys.getenv("DATABRICKS_CLUSTER_ID")
     }
     db <- import_check("databricks.connect", virtualenv_name)
     remote <- db$DatabricksSession$builder$remote(

--- a/R/spark-pyobj.R
+++ b/R/spark-pyobj.R
@@ -55,9 +55,9 @@ to_pandas_cleaned <- function(x) {
 
   dec_types <- map_lgl(orig_types, ~ grepl("decimal\\(", .x))
 
-  if(sum(dec_types) > 0) {
+  if (sum(dec_types) > 0) {
     sql_functions <- import("pyspark.sql.functions")
-    for(field in fields[dec_types]) {
+    for (field in fields[dec_types]) {
       x <- x$withColumn("r", sql_functions$col(field[[1]])$cast("double"))
     }
   }
@@ -67,14 +67,15 @@ to_pandas_cleaned <- function(x) {
     collected, ~ {
       classes <- class(.x)
       classes[[1]]
-    })
+    }
+  )
 
   list_types <- col_types == "list"
   list_vars <- col_types[list_types]
   orig_vars <- orig_types[list_types]
 
-  for(i in seq_along(list_vars)) {
-    if(orig_vars[[i]] != "array") {
+  for (i in seq_along(list_vars)) {
+    if (orig_vars[[i]] != "array") {
       cur_var <- names(list_vars[i])
       cur <- collected[[cur_var]]
       cur_null <- map_lgl(cur, is.null)

--- a/R/spark-pyobj.R
+++ b/R/spark-pyobj.R
@@ -53,6 +53,15 @@ to_pandas_cleaned <- function(x) {
   fields <- x$dtypes
   orig_types <- map_chr(fields, ~ .x[[2]])
 
+  dec_types <- map_lgl(orig_types, ~ grepl("decimal\\(", .x))
+
+  if(sum(dec_types) > 0) {
+    sql_functions <- import("pyspark.sql.functions")
+    for(field in fields[dec_types]) {
+      x <- x$withColumn("r", sql_functions$col(field[[1]])$cast("double"))
+    }
+  }
+
   collected <- x$toPandas()
   col_types <- map_chr(
     collected, ~ {

--- a/R/spark-pyobj.R
+++ b/R/spark-pyobj.R
@@ -8,7 +8,7 @@ sdf_read_column.spark_pyjobj <- function(x, column) {
 
 #' @export
 spark_version.spark_pyobj <- function(sc) {
-  sc$connection$state$spark_context$version
+  python_conn(sc)$version
 }
 
 #' @export

--- a/R/spark-pyobj.R
+++ b/R/spark-pyobj.R
@@ -56,9 +56,10 @@ to_pandas_cleaned <- function(x) {
   dec_types <- map_lgl(orig_types, ~ grepl("decimal\\(", .x))
 
   if (sum(dec_types) > 0) {
-    sql_functions <- import("pyspark.sql.functions")
+    sf <- import("pyspark.sql.functions")
     for (field in fields[dec_types]) {
-      x <- x$withColumn("r", sql_functions$col(field[[1]])$cast("double"))
+      fn <- field[[1]]
+      x <- x$withColumn(fn, sf$col(fn)$cast("double"))
     }
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -55,7 +55,6 @@ Aside from PySpark, there are several Python libraries needed for the integratio
 
 ``` r
 library(sparklyr)
-library(pysparklyr)
 
 install_pyspark()
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,7 +11,6 @@ knitr::opts_chunk$set(
   fig.path = "man/figures/README-",
   out.width = "100%"
 )
-
 ```
 
 ```{r, include = FALSE}
@@ -21,11 +20,11 @@ library(dbplyr)
 library(sparklyr)
 library(pysparklyr)
 
-install_github("sparklyr/sparklyr") 
+install_github("sparklyr/sparklyr")
 install_github("mlverse/pysparklyr")
 
 
-#install_pyspark()
+# install_pyspark()
 ```
 
 # pysparklyr
@@ -107,8 +106,8 @@ trips
 ```
 
 ```{r}
-trips %>% 
-  group_by(pickup_zip) %>% 
+trips %>%
+  group_by(pickup_zip) %>%
   summarise(
     count = n(),
     avg_distance = mean(trip_distance, na.rm = TRUE)

--- a/progress.md
+++ b/progress.md
@@ -21,6 +21,10 @@
 -   [ ] Implement Spark and Log buttons for Spark Connect and DB Connect. **Blocked** - Until SparkSession is implemented in Spark 3.5
 -   [ ] Find a way to get the Connection pane to be async to the IDE
 
+### Data 
+
+- [x] `NA`'s are not supported in numeric fields, everything is translated as `NaN`
+
 ### DBI
 
 -   [x] Integration with DBI methods. This was done my modifying a couple of `sparklyr` routines. More testing is needed to confirm all works
@@ -40,16 +44,16 @@
         - [ ] Caching does not seem to be working via regular the PySpark Dataframe op, it does work when I use SQL to cache (via `CACHE TABLE`) but can't re-partition that way
       
 -  Implement specific functions:
-    - [ ] `where()` - Needs predicate support, which is not available by default through SQL. May need to find an alternative via PySpark. This may not be needed for first CRAN release.
+    - [x] `where()` / `..._if()` - Do not plan to support predicates. Determining the field types is a very expensive operation, and it should be discouraged. `dbplyr` does not support it.  Will reconsider based on community feedback
     - [x] `sample_frac()` - Supported: `weights` No | `replace` Yes
     - [x] `sample_n()` - Supported: `weights` No | `replace` No
     - [x] `slice_max()` - Worked out-of-the-box
-    - [ ] `cumprod()` - Questioning its implementation. `sparklyr` did it via a custom Scala implementation. `dbplyr` doesn't seem to support it.
-    - [ ] `distinct()` - Mostly works. Breaks when its followed by another lazy op
+    - [x] `cumprod()` - Do not plan to support. `dbplyr` does not support it. Will reconsider based on community feedback.
+    - [x] `distinct()` 
     - [x] Hive Operators work, such as `LIKE` via `%like%` - Worked out-of-the-box
     - [ ] High Order Functions (Arrays)
     - [x] Table joins - Added `same_src()` method for PySpark connection to get it to work
-    - [ ] `lead()` / `lag()` - Works for numeric fields. For character fields, it process the windowed function but it returns a list column for some reason
+    - [x] `lead()` / `lag()` 
     - [ ] `rowSums()` - Mosts tests currently pass, but not all
     - [x] `cor()`, `cov()`, `sd()` - Worked out-of-the-box
     - [x] `weighted.mean()` - Worked out-of-the-box


### PR DESCRIPTION
- On Pandas frame cleanup, converts `decimal(x,x)` to `double`
- Updates 'progress.md'
- Updates all connection extraction code to use `python_conn()`
- Creates `tbl_pyspark_sdf()` to centralize all `pyspark$sql()` calls
- Creates `tbl_pyspark_temp()` to centralize creation of temporary tables
- Centralizes designation of `sparklyr_tmp` as the temp table prefix 
- Improvements to the test skip function
