### PR TITLE
use virtualenv instead of venv on databricks

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -50,6 +50,11 @@ install_pyspark <- function(envname = "r-sparklyr",
         "to install."
     ))
 
+  if(dir.exists("/databricks/")) {
+    # https://github.com/mlverse/pysparklyr/issues/11
+    op <- options("reticulate.virtualenv.module" = "virtualenv")
+    on.exit(options(op))
+  }
 
   # conda_install() doesn't accept a version constraint for python_version
   if(method == "conda" && python_version == ">=3.9")


### PR DESCRIPTION
The databricks environment doesn't install the apt package `python3-venv`, and the python module `venv` that reticulate discovers under the system python is not usable. 

The image however does contain an installation of `virtualenv` under `/usr/local`, which we can point reticulate at. 

closes #11