### PR TITLE
Improving spark config handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # pysparklyr (dev)
 
+* Adjusted logic for handling config to now warn users when unsupported configs
+are supplied if using Databricks serverless compute
+
+* Databricks connections should now correctly use `databricks_host()`
+
 * Adding support for Databricks serverless interactive compute (#127)
 
 * Extended authentication method support for Databricks by deferring to SDK (#127)

--- a/R/databricks-utils.R
+++ b/R/databricks-utils.R
@@ -68,14 +68,14 @@ databricks_token <- function(token = NULL, fail = FALSE) {
   token
 }
 
-databricks_sdk_client <- function(sdk,
-                                  host,
-                                  token,
-                                  serverless = FALSE,
-                                  cluster_id = NULL,
-                                  profile = NULL) {
-
-
+databricks_sdk_client <- function(
+  sdk,
+  host,
+  token,
+  serverless = FALSE,
+  cluster_id = NULL,
+  profile = NULL
+) {
   # SDK behaviour
   # https://databricks-sdk-py.readthedocs.io/en/latest/authentication.html#default-authentication-flow
   if (token == "") {
@@ -102,14 +102,15 @@ databricks_sdk_client <- function(sdk,
   )
 
   sdk$WorkspaceClient(config = config)
-
 }
 
-databricks_dbr_version_name <- function(cluster_id,
-                                        client = NULL,
-                                        host = NULL,
-                                        token = NULL,
-                                        silent = FALSE) {
+databricks_dbr_version_name <- function(
+  cluster_id,
+  client = NULL,
+  host = NULL,
+  token = NULL,
+  silent = FALSE
+) {
   bullets <- NULL
   version <- NULL
   cluster_info <- databricks_dbr_info(
@@ -137,11 +138,13 @@ databricks_extract_version <- function(x) {
   version
 }
 
-databricks_dbr_info <- function(cluster_id,
-                                client = NULL,
-                                host = NULL,
-                                token = NULL,
-                                silent = FALSE) {
+databricks_dbr_info <- function(
+  cluster_id,
+  client = NULL,
+  host = NULL,
+  token = NULL,
+  silent = FALSE
+) {
   cli_div(theme = cli_colors())
 
   if (!silent) {
@@ -200,8 +203,12 @@ databricks_dbr_info <- function(cluster_id,
   out
 }
 
-databricks_dbr_version <- function(cluster_id, client = NULL,
-                                   host = NULL, token = NULL) {
+databricks_dbr_version <- function(
+  cluster_id,
+  client = NULL,
+  host = NULL,
+  token = NULL
+) {
   vn <- databricks_dbr_version_name(
     cluster_id = cluster_id,
     client = client,
@@ -211,9 +218,12 @@ databricks_dbr_version <- function(cluster_id, client = NULL,
   vn$version
 }
 
-databricks_cluster_get <- function(cluster_id, client = NULL,
-                                   host = NULL, token = NULL) {
-
+databricks_cluster_get <- function(
+  cluster_id,
+  client = NULL,
+  host = NULL,
+  token = NULL
+) {
   if (!is.null(client)) {
     try(
       client$clusters$get(cluster_id = cluster_id)$as_dict(),
@@ -233,7 +243,6 @@ databricks_cluster_get <- function(cluster_id, client = NULL,
       silent = TRUE
     )
   }
-
 }
 
 databricks_dbr_error <- function(error) {
@@ -277,7 +286,7 @@ databricks_dbr_error <- function(error) {
 }
 
 # from httr2
-is_hosted_session <- function () {
+is_hosted_session <- function() {
   if (nzchar(Sys.getenv("COLAB_RELEASE_TAG"))) {
     return(TRUE)
   }
@@ -286,7 +295,6 @@ is_hosted_session <- function () {
 }
 
 databricks_desktop_login <- function(host = NULL, profile = NULL) {
-
   # host takes priority over profile
   if (!is.null(host)) {
     method <- "--host"
@@ -341,3 +349,12 @@ sanitize_host <- function(url, silent = FALSE) {
   ret
 }
 
+# https://docs.databricks.com/aws/en/release-notes/serverless#supported-spark-configuration-parameters
+allowed_serverless_configs <- function() {
+  c(
+    "spark.sql.legacy.timeParserPolicy",
+    "spark.sql.session.timeZone",
+    "spark.sql.shuffle.partitions",
+    "spark.sql.ansi.enabled"
+  )
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,11 @@
 #' @return The result of calling `rhs(lhs)`.
 NULL
 
-reticulate_python_check <- function(ignore = FALSE, unset = FALSE, message = TRUE) {
+reticulate_python_check <- function(
+  ignore = FALSE,
+  unset = FALSE,
+  message = TRUE
+) {
   if (ignore) {
     return("")
   }
@@ -94,9 +98,10 @@ current_product_connect <- function() {
 }
 
 py_check_installed <- function(
-    envname = NULL,
-    libraries = "",
-    msg = "") {
+  envname = NULL,
+  libraries = "",
+  msg = ""
+) {
   installed_libraries <- py_list_packages(envname = envname)$package
   find_libs <- map_lgl(libraries, ~ .x %in% installed_libraries)
   if (!all(find_libs)) {
@@ -130,4 +135,15 @@ stop_quietly <- function() {
 
 use_arrow <- function() {
   arrow::binary()
+}
+
+list_diff <- function(x, y) {
+  x_names <- names(x)
+  y_names <- names(y)
+
+  # Find elements that are either:
+  c(
+    x[setdiff(x_names, y_names)], # 1. New names in x
+    x[!mapply(identical, x[y_names], y)] # 2. Same name but different value
+  )
 }


### PR DESCRIPTION
- removes default sparklyr configs
- removes any configs mentioning sparklyr
- if its not using serverless, add the pyspark confs
- if its using serverless, remove any unpermitted confs AND warn the user that they were unsupported

Also corrected behaviour with `master` (host) not using `databricks_host` correctly.