### PR TITLE
specify default origin

### DIFF
--- a/R/python-to-pandas-cleaned.R
+++ b/R/python-to-pandas-cleaned.R
@@ -39,7 +39,7 @@ to_pandas_cleaned <- function(x) {
     if (orig_types[i] == "date") {
       to_date <- collected[, i] %>%
         as.integer() %>%
-        as.Date()
+        as.Date(origin = "1970-01-01")
       collected[, i] <- to_date
     }
   }


### PR DESCRIPTION
fixes https://github.com/sparklyr/sparklyr/issues/3448

@edgararuiz Testing on databricks I was getting the same issue as this sparklyr issue, which I traced to this line https://github.com/mlverse/pysparklyr/blob/b839f845a41518e8f5f990bfd4dfd22b6023b3f8/R/python-to-pandas-cleaned.R#L42. Testing on my data it was fixed by specifying the default origin