### PR TITLE
Fix token check to handle NULL values in Databricks connection

### DIFF
--- a/R/connect-databricks.R
+++ b/R/connect-databricks.R
@@ -62,7 +62,7 @@ spark_connect_method.spark_method_databricks_connect <- function(
   dbc <- import_check("databricks.connect", envname, silent)
   db_sdk <- import_check("databricks.sdk", envname, silent = TRUE)
 
-  if (token == "") {
+  if (is.null(token) || token == "") {
     sdk_config <- db_sdk$core$Config()
     token <- sdk_config$token %||% ""
   }


### PR DESCRIPTION
The token handling is distributed and a mix between NULL and empty string checks. I just fixed that it works with Databricks CLI and OAUTH. 