### PR TITLE
Fully delegate Snowflake auth to the SDK and add Connect support

### DIFF
--- a/.github/workflows/spark-tests.yaml
+++ b/.github/workflows/spark-tests.yaml
@@ -67,6 +67,7 @@ jobs:
             any::tidymodels
             any::probably
             any::rpart
+            any::connectcreds
           needs: check
 
       - name: Cache Spark

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -69,6 +69,7 @@ jobs:
             any::probably
             any::rpart
             any::pak
+            any::connectcreds
           needs: check
 
       - name: Install sparklyr dev

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 - Adds support for `tune_grid_spark()`. It enables running a Tidymodels tune
 grid inside Spark Connect clusters.
 
+* Snowflake connections now support all native authenticators via the Snowflake
+  Python SDK, which also picks up on default credentials from Snowflake
+  `connections.toml` files. Viewer-based credentials on Posit Connect are now
+  supported, too (#181 - @atheriel).
+
 ### Improvements
 
 - Databricks Connect now auto-detects the latest library version from PyPI when

--- a/R/connect-snowflake.R
+++ b/R/connect-snowflake.R
@@ -12,14 +12,10 @@ spark_connect_method.spark_method_snowpark_connect <- function(
   scala_version,
   ...
 ) {
-  if (missing(master) || is.null(master)) {
+  master_explicit <- !missing(master) && !is.null(master)
+  if (!master_explicit) {
     master <- Sys.getenv("SNOWFLAKE_ACCOUNT", unset = NA)
-    if (is.na(master)) {
-      cli_abort(paste(
-        "Please provide a `master` argument. It needs to be your Snowflake's",
-        "'Account Identifier', which can be found in the portal."
-      ))
-    }
+    if (is.na(master)) master <- NULL
   }
   args <- list(...)
   envname <- use_envname(
@@ -36,45 +32,58 @@ spark_connect_method.spark_method_snowpark_connect <- function(
   }
   pyspark <- import_check("snowflake.snowpark", envname)
   connection_parameters <- args$connection_parameters %||% list()
-  connection_parameters$account <- master
-  if (is.null(connection_parameters$password)) {
-    # Checks to see if there is a Posit Workbench token available
-    snowflake_home <- Sys.getenv("SNOWFLAKE_HOME", unset = NA)
-    if (!is.na(snowflake_home)) {
-      if (grepl("workbench", snowflake_home)) {
-        token <- try(
-          workbench_snowflake_token(master, snowflake_home),
-          silent = TRUE
-        )
-        if (!inherits(token, "try-error")) {
-          connection_parameters$authenticator <- "oauth"
-          connection_parameters$token <- token
-        }
-      }
+
+  using_named_connection <-
+    !is.null(connection_parameters$connection_name) ||
+    nzchar(Sys.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME"))
+
+  effective_account <- if (!using_named_connection || master_explicit) {
+    master %||% connection_parameters$account
+  } else {
+    connection_parameters$account
+  }
+  snowflake_url <- if (!is.null(effective_account)) {
+    paste0("https://", effective_account, ".snowflakecomputing.com")
+  }
+
+  if (!is.null(snowflake_url) && has_viewer_token(snowflake_url)) {
+    token_obj <- connect_viewer_token(snowflake_url)
+    connection_parameters$account <- effective_account
+    connection_parameters$authenticator <- "oauth"
+    connection_parameters$token <- token_obj$access_token
+  } else if (!is.null(master) && (!using_named_connection || master_explicit)) {
+    connection_parameters$account <- master
+  }
+
+  if (!using_named_connection && !is.null(master)) {
+    missing_path <- NULL
+    if (is.null(connection_parameters$warehouse)) {
+      missing_path <- "warehouse"
+    }
+    if (is.null(connection_parameters$database)) {
+      missing_path <- c(missing_path, "database")
+    }
+    if (is.null(connection_parameters$schema)) {
+      missing_path <- c(missing_path, "schema")
+    }
+    if (!is.null(missing_path)) {
+      missing_path <- paste0("'", missing_path, "'")
+      cli_alert_warning(
+        "Argument{?s} {.pkg {missing_path}} will be needed to easily navigate Snowflake"
+      )
+      cli_bullets(
+        c(" " = "Please use the `connection_parameters` argument to pass them.")
+      )
     }
   }
-  missing_path <- NULL
-  if (is.null(connection_parameters$warehouse)) {
-    missing_path <- "warehouse"
-  }
-  if (is.null(connection_parameters$database)) {
-    missing_path <- c(missing_path, "database")
-  }
-  if (is.null(connection_parameters$schema)) {
-    missing_path <- c(missing_path, "schema")
-  }
-  if (!is.null(missing_path)) {
-    missing_path <- paste0("'", missing_path, "'")
-    cli_alert_warning(
-      "Argument{?s} {.pkg {missing_path}} will be needed to easily navigate Snowflake"
-    )
-    cli_bullets(
-      c(" " = "Please use the `connection_parameters` argument to pass them.")
-    )
-  }
+
   conn <- pyspark$Session$builder$configs(connection_parameters)
   con_class <- "connect_snowflake"
-  master_label <- glue("Snowpark Connect - {master}")
+  master_label <- if (!is.null(effective_account)) {
+    glue("Snowpark Connect - {effective_account}")
+  } else {
+    "Snowpark Connect"
+  }
   initialize_connection(
     conn = conn,
     master_label = master_label,
@@ -96,22 +105,3 @@ spark_connect_method.spark_method_snowpark_connect <- function(
 setOldClass(
   c("connect_snowflake", "pyspark_connection", "spark_connection")
 )
-
-# Copy of code from `odbc` which gets the Snowflake token from Workbench
-# https://github.com/r-dbi/odbc/blob/main/R/driver-snowflake.R
-workbench_snowflake_token <- function(account, sf_home) {
-  cfg <- readLines(file.path(sf_home, "connections.toml"))
-  # We don't attempt a full parse of the TOML syntax, instead relying on the
-  # fact that this file will always contain only one section.
-  if (!any(grepl(account, cfg, fixed = TRUE))) {
-    # The configuration doesn't actually apply to this account.
-    return(NULL)
-  }
-  line <- grepl("token = ", cfg, fixed = TRUE)
-  token <- gsub("token = ", "", cfg[line])
-  if (nchar(token) == 0) {
-    return(NULL)
-  }
-  # Drop enclosing quotes.
-  gsub("\"", "", token)
-}

--- a/tests/testthat/test-zzz-spark-connect.R
+++ b/tests/testthat/test-zzz-spark-connect.R
@@ -50,7 +50,10 @@ test_that("Databricks Connect", {
 test_that("Snowpark Connect (Snowflake)", {
   withr::with_envvar(
     new = c(
-      "WORKON_HOME" = use_test_env()
+      "WORKON_HOME" = use_test_env(),
+      "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+      "SNOWFLAKE_ACCOUNT" = NA,
+      "RSTUDIO_PRODUCT" = NA
     ),
     {
       local_mocked_bindings(
@@ -80,20 +83,223 @@ test_that("Snowpark Connect (Snowflake)", {
         )
       )
       expect_snapshot(sc_out)
-      expect_error(
-        spark_connect_method.spark_method_snowpark_connect(
-          method = "snowpark_connect",
-          connection_parameters = list(
-            user = "test@user.com",
-            password = "testtoken",
-            warehouse = "testwh",
-            database = "testdb",
-            schema = "testschema"
-          )
+      sc_no_master <- spark_connect_method.spark_method_snowpark_connect(
+        method = "snowpark_connect",
+        connection_parameters = list(
+          user = "test@user.com",
+          password = "testtoken",
+          warehouse = "testwh",
+          database = "testdb",
+          schema = "testschema"
         )
       )
+      expect_equal(sc_no_master$master_label, "Snowpark Connect")
+      expect_null(sc_no_master$conn[[1]]$account)
     }
   )
+})
+
+test_that("Snowpark Connect works with connection_name, no master", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = NA,
+    "RSTUDIO_PRODUCT" = NA
+  ))
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    connection_parameters = list(
+      connection_name = "myconn"
+    )
+  )
+  expect_equal(sc_out$master_label, "Snowpark Connect")
+  expect_null(sc_out$conn[[1]]$account)
+})
+
+test_that("Snowpark Connect works with SNOWFLAKE_DEFAULT_CONNECTION_NAME", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = "default",
+    "SNOWFLAKE_ACCOUNT" = NA,
+    "RSTUDIO_PRODUCT" = NA
+  ))
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect"
+  )
+  expect_equal(sc_out$master_label, "Snowpark Connect")
+})
+
+test_that("Snowpark Connect named connection ignores SNOWFLAKE_ACCOUNT env var", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = "env-account",
+    "RSTUDIO_PRODUCT" = NA
+  ))
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    connection_parameters = list(
+      connection_name = "myconn"
+    )
+  )
+  expect_null(sc_out$conn[[1]]$account)
+})
+
+test_that("Snowpark Connect named connection ignores env account with viewer token", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = "env-account"
+  ))
+  connectcreds::local_mocked_connect_responses(token = "viewer-token-value")
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    connection_parameters = list(
+      connection_name = "myconn"
+    )
+  )
+  expect_null(sc_out$conn[[1]]$account)
+  expect_null(sc_out$conn[[1]]$authenticator)
+  expect_equal(sc_out$master_label, "Snowpark Connect")
+})
+
+test_that("Snowpark Connect uses connectcreds viewer token", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = NA
+  ))
+  connectcreds::local_mocked_connect_responses(token = "viewer-token-value")
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    master = "testaccount"
+  )
+  expect_equal(sc_out$conn[[1]]$authenticator, "oauth")
+  expect_equal(sc_out$conn[[1]]$token, "viewer-token-value")
+  expect_equal(sc_out$conn[[1]]$account, "testaccount")
+  expect_equal(sc_out$master_label, "Snowpark Connect - testaccount")
+})
+
+test_that("Snowpark Connect uses connectcreds with account in connection_parameters", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = NA
+  ))
+  connectcreds::local_mocked_connect_responses(token = "viewer-token-value")
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    connection_parameters = list(
+      account = "testaccount"
+    )
+  )
+  expect_equal(sc_out$conn[[1]]$authenticator, "oauth")
+  expect_equal(sc_out$conn[[1]]$token, "viewer-token-value")
+  expect_equal(sc_out$conn[[1]]$account, "testaccount")
+  expect_equal(sc_out$master_label, "Snowpark Connect - testaccount")
+})
+
+test_that("Snowpark Connect viewer token overrides explicit credentials", {
+  withr::local_envvar(c(
+    "WORKON_HOME" = use_test_env(),
+    "SNOWFLAKE_DEFAULT_CONNECTION_NAME" = NA,
+    "SNOWFLAKE_ACCOUNT" = NA
+  ))
+  connectcreds::local_mocked_connect_responses(token = "viewer-token-value")
+  local_mocked_bindings(
+    initialize_connection = function(...) {
+      return(list(...))
+    },
+    import_check = function(...) {
+      out <- list()
+      out$Session$builder$configs <- function(...) {
+        list(...)
+      }
+      out
+    }
+  )
+  sc_out <- spark_connect_method.spark_method_snowpark_connect(
+    method = "snowpark_connect",
+    master = "testaccount",
+    connection_parameters = list(
+      password = "explicit-password",
+      authenticator = "snowflake"
+    )
+  )
+  expect_equal(sc_out$conn[[1]]$authenticator, "oauth")
+  expect_equal(sc_out$conn[[1]]$token, "viewer-token-value")
 })
 
 test_that("installed_components() output properly", {


### PR DESCRIPTION
Previously we had special handling for a couple of different authenticators but didn't natively support the default connection behaviour of the Snowflake SDKs (and `odbc::snowflake()`). This commit delegates all of the auth handling to the Python SDK, giving us all supported authenticators for free.

The only auth method requiring specific R-side code is viewer credentials on Posit Connect, which we now get via `connectcreds` (like we do for Databricks already).

Unit tests are included.