### PR TITLE
fix: correct control incompatibility message

### DIFF
--- a/R/tune-grid.R
+++ b/R/tune-grid.R
@@ -470,7 +470,7 @@ prep_static <- function(
   }
   if (!is.null(control_err)) {
     abort(c(
-      "The following incompatability errors in `control` were found:",
+      "The following incompatibility errors in `control` were found:",
       control_err
     ))
   }


### PR DESCRIPTION
## Summary
- Correct a user-facing typo in the control validation error message: `incompatability` -> `incompatibility`.
## Verification
- Checked locally that the old misspelling is gone and the corrected wording is present.
- - Final diff contains only the intended string change.